### PR TITLE
Enable skipping reloads on a configured cycle.

### DIFF
--- a/revolver_tabs/manifest.json
+++ b/revolver_tabs/manifest.json
@@ -13,5 +13,5 @@
    "name": "Revolver - Tabs",
    "options_page": "options.html",
    "permissions": [ "tabs", "idle" ],
-   "version": "0.71"
+   "version": "0.72"
 }

--- a/revolver_tabs/options.html
+++ b/revolver_tabs/options.html
@@ -30,6 +30,7 @@ img.icon {height:15px;width:15px;margin-right:5px}
 <p><label for="seconds">Seconds:</label> <input type="text" name="seconds" id="seconds" style="width:30px;"><span class="example">The number of seconds to show a tab before switching ex. <strong>10</strong></span></p>
 <p><label for="autostart">Auto Start:</label> <input type="checkbox" name="autostart" id="autostart"><span class="example">Automatically start Revolver Tabs on browser startup.</span></p>
 <p><label for="reload">Reload:</label> <input type="checkbox" name="reload" id="reload"><span class="example">Check this box to reload the tab each time before it is shown.</span></p>
+<p><label for="numCyclesSkipReload">Only reload every x cycles:</label> <input type="text" name="numCyclesSkipReload" id="numCyclesSkipReload" style="width:30px;"><span class="example">The number of cycles to pass through the tabs before reloading (Reload box must be checked)</span></p>
 <p><label for="noRefreshList">Blacklist for URLs that should not be reloaded:</label> <textarea name="noRefreshList" id="noRefreshList" rows="10" cols="80"></textarea><span class="example">The list should have full URLs, each separated by a new line</span></p>
 <p><label for="inactive">Rotate only when inactive:</label> <input type="checkbox" name="inactive" id="inactive"><span class="example"><strong>Rotation will pause</strong> if the browser has been interacted with within 15 seconds.</span></p>
 <button id="save">Save</button><span id="status"></span>

--- a/revolver_tabs/options.html
+++ b/revolver_tabs/options.html
@@ -38,7 +38,7 @@ img.icon {height:15px;width:15px;margin-right:5px}
 <div id="adv-settings" class="adv-settings" style="margin-top:10px">
 <p>Advanced Settings <span class="example">Select the checkbox to enable individual settings on a tab</span></p>
 </div>
-<p class="thanks">Special thanks for <a href="https://code.google.com/p/revolver-chrome-extensions/">open source code contributions</a> from Fred Emmott, Aurimas Liutikas and Wayne Goyer.</p>
+<p class="thanks">Special thanks for <a href="https://github.com/benhedrington/revolver-chrome-extensions">open source code contributions</a> from Fred Emmott, Aurimas Liutikas, Ben Patterson and Wayne Goyer.</p>
 </body>
 <script src="options_script.js"></script>
 </html>

--- a/revolver_tabs/options_script.js
+++ b/revolver_tabs/options_script.js
@@ -14,11 +14,13 @@ function saveBaseOptions(callback) {
         status = document.getElementById("status");
     appSettings.seconds = document.getElementById("seconds").value;
     bg.timeDelay = (document.getElementById("seconds").value*1000);
+    appSettings.numCyclesSkipReload = document.getElementById("numCyclesSkipReload").value;
+    bg.numCyclesSkipReload = document.getElementById("numCyclesSkipReload").value;
     getCheckedStatus(appSettings, "reload");
     getCheckedStatus(appSettings, "inactive");
     getCheckedStatus(appSettings, "autostart");
     appSettings.noRefreshList = document.getElementById('noRefreshList').value.split('\n');
-    bg.noRefreshList = document.getElementById('noRefreshList').value.split('\n');  
+    bg.noRefreshList = document.getElementById('noRefreshList').value.split('\n');
     status.innerHTML = "OPTIONS SAVED";
     setTimeout(function() {
         status.innerHTML = "";
@@ -41,17 +43,18 @@ function restoreOptions() {
     var appSettings = {};
     if (localStorage["revolverSettings"]) appSettings = JSON.parse(localStorage["revolverSettings"]);
         document.getElementById("seconds").value = (appSettings.seconds || 10);
+        document.getElementById("numCyclesSkipReload").value = (appSettings.numCyclesSkipReload || 0);
         document.getElementById("reload").checked = (appSettings.reload || false);
         document.getElementById("inactive").checked = (appSettings.inactive || false);
         document.getElementById("autostart").checked = (appSettings.autostart || false);
         if(appSettings.noRefreshList && appSettings.noRefreshList.length > 0){
             for(var i=0;i<appSettings.noRefreshList.length;i++){
                 if(appSettings.noRefreshList[i]!= ""){
-                    document.getElementById("noRefreshList").value += (appSettings.noRefreshList[i]+"\n");    
+                    document.getElementById("noRefreshList").value += (appSettings.noRefreshList[i]+"\n");
                 };
             };
         } else {
-            document.getElementById("noRefreshList").value = "";    
+            document.getElementById("noRefreshList").value = "";
         }
 }
 


### PR DESCRIPTION
When feature is in use, reloading of the given tabs will occur on a cycle. For example, if the cycle is set to 5, the tabs will revolve as usual; however, they will only reload on every 5th revolution.
